### PR TITLE
Require Duster and include default Action

### DIFF
--- a/.github/workflows/duster-fix.yml
+++ b/.github/workflows/duster-fix.yml
@@ -1,0 +1,32 @@
+name: Duster Fix
+
+# Commits made in here will not trigger any workflows
+# Checkout Duster's documentation for a workaround
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+
+jobs:
+  duster:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: "Duster Fix"
+        uses: tighten/duster-action@v2
+        with:
+          args: fix
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Dusting
+          commit_user_name: GitHub Action
+          commit_user_email: actions@github.com

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "mockery/mockery": "^1.6",
     "nunomaduro/larastan": "^2.6",
     "nunomaduro/termwind": "^1.15",
-    "pestphp/pest": "^2.8"
+    "pestphp/pest": "^2.8",
+    "tightenco/duster": "^2.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Let's test Duster's GitHub Action. How does just linting appear?